### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This file resolves an issue where contributors using Windows may commit incorrect line endings. This is currently an issue with #12 which is causing `.husky/pre-commit` to fail due to the line ending being included in the `bash` directive.

For more information, see https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings