### PR TITLE
Add consistent top navigation on all pages

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,5 @@
-// import { ConnectButton } from '@rainbow-me/rainbowkit'
-import { Flex } from '@chakra-ui/react'
-import SchoolOfCodeLogo from './SchoolOfCodeLogo'
+import NavBar from '../components/NavBar'
 
 export default function Header() {
-  return (
-    <Flex display="flex" direction="row" align="end" justify="space-between">
-      <SchoolOfCodeLogo autoStart={true} loop={true} />
-      {/* <ConnectButton chainStatus="icon" showBalance={false} /> */}
-    </Flex>
-  )
+  return <NavBar />
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Button,
   Center,
+  Link,
 } from '@chakra-ui/react'
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import Image from 'next/image'
@@ -37,16 +38,18 @@ const Hero = () => {
                 of building web3 Open Source.
               </Text>
 
-              <Button
-                colorScheme="pink"
-                size="lg"
-                bgGradient="linear(to-tl, #FF6D9A , #5F4ADF)"
-                color="white"
-                alignSelf={{ base: 'center', md: 'flex-start' }}
-                leftIcon={<ArrowForwardIcon />}
-              >
-                Get Started
-              </Button>
+              <Link href={'/lessons'}>
+                <Button
+                  colorScheme="pink"
+                  size="lg"
+                  bgGradient="linear(to-tl, #FF6D9A , #5F4ADF)"
+                  color="white"
+                  alignSelf={{ base: 'center', md: 'flex-start' }}
+                  leftIcon={<ArrowForwardIcon />}
+                >
+                  Get Started
+                </Button>
+              </Link>
             </VStack>
           </VStack>
 

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import NextLink from 'next/link'
+import { useRouter } from 'next/router'
 import {
   Image,
   Box,
@@ -14,6 +16,8 @@ import SchoolOfCodeLogo from './SchoolOfCodeLogo'
 // import { ConnectButton } from '@rainbow-me/rainbowkit'
 
 function NavBar() {
+  const router = useRouter()
+
   return (
     <Box>
       <Flex justify="left" alignItems="center">
@@ -23,12 +27,30 @@ function NavBar() {
         <Spacer />
         <Box>
           <Flex alignItems="center">
-            <Link variant="top-navigation" href={'/'}>
-              Home
-            </Link>
-            <Link variant="top-navigation" href={'/lessons'}>
-              Tracks
-            </Link>
+            <NextLink href="/" passHref>
+              <Link
+                variant={
+                  router.pathname === '/'
+                    ? 'top-navigation-active'
+                    : 'top-navigation'
+                }
+              >
+                Home
+              </Link>
+            </NextLink>
+
+            <NextLink href="/lessons" passHref>
+              <Link
+                variant={
+                  router.pathname.startsWith('/lessons')
+                    ? 'top-navigation-active'
+                    : 'top-navigation'
+                }
+              >
+                Tracks
+              </Link>
+            </NextLink>
+
             {/* <Button colorScheme="gray" variant="solid">
               <ConnectButton chainStatus="icon" showBalance={false} />
             </Button> */}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -10,31 +10,33 @@ import {
   IconButton,
 } from '@chakra-ui/react'
 import HamburgerIcon from './HamburgerIcon'
+import SchoolOfCodeLogo from './SchoolOfCodeLogo'
+// import { ConnectButton } from '@rainbow-me/rainbowkit'
 
 function NavBar() {
   return (
-    <Box pl="235px" pr="235px">
-      <Flex justify="center" alignItems="center">
-        <Box my={-20}>
-          <Image
-            boxSize={{ base: '120px', md: '300px' }}
-            src="/public/assets/logo.svg"
-          />
-        </Box>
+    <Box>
+      <Flex justify="left" alignItems="center">
+        <Link variant="logo" href={'/'}>
+          <SchoolOfCodeLogo autoStart={true} loop={true} />
+        </Link>
         <Spacer />
         <Box>
           <Flex alignItems="center">
-            <Link pr="9" color="yellow.300">
-              JOIN THE COMMUNITY
+            <Link variant="top-navigation" href={'/'}>
+              Home
             </Link>
-            <Button colorScheme="gray" variant="solid">
-              Connect Wallet
-            </Button>
-            <IconButton
+            <Link variant="top-navigation" href={'/lessons'}>
+              Tracks
+            </Link>
+            {/* <Button colorScheme="gray" variant="solid">
+              <ConnectButton chainStatus="icon" showBalance={false} />
+            </Button> */}
+            {/* <IconButton
               aria-label="Search database"
               variant="ghost"
               icon={<HamburgerIcon />}
-            />
+            /> */}
           </Flex>
         </Box>
       </Flex>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -5,11 +5,14 @@ import {
   Image,
   Box,
   Flex,
-  Heading,
   Button,
   Spacer,
   Link,
   IconButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
 } from '@chakra-ui/react'
 import HamburgerIcon from './HamburgerIcon'
 import SchoolOfCodeLogo from './SchoolOfCodeLogo'
@@ -26,7 +29,52 @@ function NavBar() {
         </Link>
         <Spacer />
         <Box>
-          <Flex alignItems="center">
+          {/*
+                MOBILE / HAMBURGER MENU
+          */}
+          <Flex alignItems="center" display={{ base: 'block', md: 'none' }}>
+            <Menu autoSelect={false}>
+              <MenuButton
+                as={IconButton}
+                aria-label="Options"
+                icon={<HamburgerIcon />}
+                variant="outline"
+              />
+              <MenuList backgroundColor={'soc.vividViolet'}>
+                <MenuItem>
+                  <NextLink href="/" passHref>
+                    <Link
+                      variant={
+                        router.pathname === '/'
+                          ? 'top-navigation-active'
+                          : 'top-navigation'
+                      }
+                    >
+                      Home
+                    </Link>
+                  </NextLink>
+                </MenuItem>
+                <MenuItem>
+                  <NextLink href="/lessons" passHref>
+                    <Link
+                      variant={
+                        router.pathname.startsWith('/lessons')
+                          ? 'top-navigation-active'
+                          : 'top-navigation'
+                      }
+                    >
+                      Tracks
+                    </Link>
+                  </NextLink>
+                </MenuItem>
+              </MenuList>
+            </Menu>
+          </Flex>
+
+          {/*
+                DESKTOP VERSION
+          */}
+          <Flex alignItems="center" display={{ base: 'none', md: 'block' }}>
             <NextLink href="/" passHref>
               <Link
                 variant={
@@ -54,11 +102,6 @@ function NavBar() {
             {/* <Button colorScheme="gray" variant="solid">
               <ConnectButton chainStatus="icon" showBalance={false} />
             </Button> */}
-            {/* <IconButton
-              aria-label="Search database"
-              variant="ghost"
-              icon={<HamburgerIcon />}
-            /> */}
           </Flex>
         </Box>
       </Flex>

--- a/theme.ts
+++ b/theme.ts
@@ -48,6 +48,19 @@ const components = {
         color: 'yellow.300',
         textTransform: 'uppercase',
         fontWeight: 'bold',
+        p: '4px',
+      },
+      'top-navigation-active': {
+        mr: 9,
+        color: 'black',
+        textTransform: 'uppercase',
+        fontWeight: 'bold',
+        backgroundColor: 'yellow.300',
+        p: '4px',
+        borderRadius: '4px',
+        _hover: {
+          textDecoration: 'none',
+        },
       },
       logo: {
         _hover: {

--- a/theme.ts
+++ b/theme.ts
@@ -40,6 +40,24 @@ const styles = {
   },
 }
 
+const components = {
+  Link: {
+    variants: {
+      'top-navigation': {
+        mr: 9,
+        color: 'yellow.300',
+        textTransform: 'uppercase',
+        fontWeight: 'bold',
+      },
+      logo: {
+        _hover: {
+          textDecoration: 'none',
+        },
+      },
+    },
+  },
+}
+
 export const theme = extendTheme({
   config: {
     initialColorMode: 'dark',
@@ -130,4 +148,5 @@ export const theme = extendTheme({
       maxWidth: '10vw',
     },
   },
+  components,
 })


### PR DESCRIPTION
DESKTOP:

<img width="921" alt="Screen Shot 2022-07-21 at 5 29 11 PM" src="https://user-images.githubusercontent.com/139330/180336792-275fb0eb-1a12-4250-a397-c43d4c2bff50.png">

MOBILE:

<img width="704" alt="Screen Shot 2022-07-21 at 5 24 07 PM" src="https://user-images.githubusercontent.com/139330/180336714-6501e242-cd15-4f69-ac72-9a6810b1a94f.png">

## Includes

- Add consistent nav across all pages using `<NavBar>`. Style it. Move logo out of `<Header>` and into `<NavBar>`.
- Logo is now a link that goes to home page
- Using term "Tracks" (which will soon replace the word "Lessons" in #38)
- Highlight active navigation based on route
- Use NextJS ‘NextLink’ tag with Chakra ‘Link’ tag (instead of only Chakra Link tag).
- Hamburger menu for mobile.

Closes #33

## Plus

- Hook up "Getting Started" button -- #36 