### PR TITLE
Add script to confirm good-to-go before PR submitted. Document process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ to the guide can be found
 This will create a local instance of the app running and can be viewed at
 `http://localhost:3000` in your browser.
 
+Also it's handy to install the Prettier plugin for your browser. You can then
+use it to automatically format files. It helps keep the code base tiday, for
+Typescript, MDX and Markdown files.
+
 ## Grabbing latest version of the code
 
 **Since this is a work in progress, your local version of the app can be updated
@@ -46,6 +50,25 @@ Reinstall with `yarn`:
 Run the updated app:
 
     yarn dev
+
+## Submit your changes and create a Pull Request
+
+Before pushing your branch to GitHub and opening a PR:
+
+- Run `yarn confirm` which will make sure your files are consistently formatted,
+  lint the code base looking for problems and then actually building the site
+  locally to ensure no build problems
+- If you see warnings or errors please fix.
+- Also, this step runs Prettier so some files may have changed and need to be
+  checked in.
+
+Now everything should be ready-to-go. You may have to run this process several
+times.
+
+Just push your branch and open a PR, and send a quick note on Discord to let the
+team know you're looking for a review.
+
+Thank you for your contribution!
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --max-warnings=0",
     "prepare": "husky install",
     "test": "jest",
     "storybook": "start-storybook -p 6006 -s ./public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "style": "prettier --write ./pages ./components ./lessons ./README.md",
+    "confirm": "yarn style && yarn lint && yarn build"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.0.1",


### PR DESCRIPTION
- Document process in README
- Create a `yarn confirm` step to run Prettier, run lint and run build so errors can be fixed before submitting PR.
- I **intentionally** didn't push up some files that needed formatting so it doesn't conflict with existing PRs.

<img width="941" alt="Screen Shot 2022-08-20 at 11 57 01 AM" src="https://user-images.githubusercontent.com/139330/185762538-b6c0afcd-59f7-4c19-a622-8fa529767dd8.png">

