### PR TITLE
Fix issue #81

### DIFF
--- a/components/ContentSideDrawer.tsx
+++ b/components/ContentSideDrawer.tsx
@@ -24,6 +24,11 @@ function ContentSideDrawer(props: any) {
         fontWeight="bold"
         bg="gray.700"
         mt="1em"
+        height={[`${props.title.length > 30 ? '3.75rem' : '2.5rem'}`, '2.5rem']}
+        style={{
+          whiteSpace: 'normal',
+          wordWrap: 'break-word',
+        }}
       >
         {props.title}&nbsp;&nbsp;
         <ArrowRightIcon />


### PR DESCRIPTION
I used the same properties @PBillingsby used to fix the related issue #53. ContentSideDrawer component text now don't overflow.