### PR TITLE
Bug/accessibility fixes

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -44,19 +44,21 @@ const Hero = () => {
                 of building web3 Open Source.
               </Text>
 
-              <Button
-                colorScheme="pink"
-                size="lg"
-                fontSize="2xl"
-                fontWeight="700"
-                p="2rem"
-                bgGradient="linear(to-tl, #FF6D9A , #5F4ADF)"
-                color="white"
-                alignSelf={{ base: 'center', md: 'flex-start' }}
-                leftIcon={<ArrowForwardIcon />}
-              >
-                <Link href={'/getting-started'}>Get Started</Link>
-              </Button>
+              <Link href={'/getting-started'}>
+                <Button
+                  colorScheme="pink"
+                  size="lg"
+                  fontSize="2xl"
+                  fontWeight="700"
+                  p="2rem"
+                  bgGradient="linear(to-tl, #FF6D9A , #5F4ADF)"
+                  color="white"
+                  alignSelf={{ base: 'center', md: 'flex-start' }}
+                  leftIcon={<ArrowForwardIcon />}
+                >
+                  Get Started
+                </Button>
+              </Link>
             </VStack>
           </VStack>
 

--- a/pages/getting-started/index.tsx
+++ b/pages/getting-started/index.tsx
@@ -95,13 +95,14 @@ const GettingStarted: React.FC<LessonProps> = ({ lessons }) => {
                           `${
                             lesson.frontMatter.title.length > 30
                               ? '3.75rem'
-                              : '2.5rem'
+                              : '3.25rem'
                           }`,
-                          '2.5rem',
+                          '3.25rem',
                         ]}
                         style={{
                           whiteSpace: 'normal',
                           wordWrap: 'break-word',
+                          padding: '0.25rem',
                         }}
                       >
                         {lesson.slug}: {lesson.frontMatter.title}

--- a/pages/lessons/[slug].tsx
+++ b/pages/lessons/[slug].tsx
@@ -38,7 +38,7 @@ const components = {
       )
     }
 
-    return <Code fontSize="md" {...props} />
+    return <Code fontSize="md" wordBreak="break-all" {...props} />
   },
   h1: (props: any) => (
     <Heading as="h1" apply="mdx.h1" fontSize="4xl" {...props} />


### PR DESCRIPTION
Closes #96 #97 #98 

- Entire Hero CTA button works as a link, not just the text
- Added `word-wrap` to inline code props in [slug].tsx. This fixes the overflow issue. Image added for reference.
<img width="263" alt="image" src="https://user-images.githubusercontent.com/50047129/188410001-31e0d7f7-d9c9-42ab-bae7-11312cb92642.png">
- A padding on the Button element solves the text overflow issue on lessons list in getting started page. Image added for reference.
<img width="242" alt="image" src="https://user-images.githubusercontent.com/50047129/188410300-224fe3be-9a59-490b-b1af-bf3be255d66b.png">

